### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
         <h3 style="text-align:center">Useful Links</h3>
         <div class="btn-group">
            <button onclick="window.location.href='https://portal.nersc.gov/project/cosmo/data/CatWISE/'">
-             <font color="red">Warning! a0 files need updating! CatWISE Data Access </font>
+            CatWISE Data Access  
           </button>
           <button onclick="window.open('CatWISEoverview2019jun06.pdf')">   
             CatWISE Overview Paper
@@ -444,14 +444,7 @@
             <a href='https://www.nasa.gov/mission_pages/neowise/mission/index.html'>NEOWISE</a> 
             survey data.
           </p>
-          <p>
-            <font color="red">Warning! 
-            There is a flaw in the CatWISE Preliminary catalog and reject files available at  
-            https://portal.nersc.gov/project/cosmo/data/CatWISE. These files end in ``a0.tbl.gz.''
-            Duplicate measurements for sources in the 3 arcmin overlap region between the 1.56 deg tiles
-            were inadvertently included in the catalog files rather than in the reject files.  
-            We are updating the files (which will end in ``a1.tbl.gz'') to correct this error.    </font>
-          </p>
+          
           <p>
             CatWISE adapts AllWISE software to measure the sources in co-added images
             created by the unWISE team from six month subsets of these data, 


### PR DESCRIPTION
deleted these lines at 447 in anticipation of a1 catalog:
<p>
            <font color="red">Warning! 
            There is a flaw in the CatWISE Preliminary catalog and reject files available at  
            https://portal.nersc.gov/project/cosmo/data/CatWISE. These files end in ``a0.tbl.gz.''
            Duplicate measurements for sources in the 3 arcmin overlap region between the 1.56 deg tiles
            were inadvertently included in the catalog files rather than in the reject files.  
            We are updating the files (which will end in ``a1.tbl.gz'') to correct this error.    </font>
          </p>
]and line 389:
<font color="red">Warning! a0 files need updating! CatWISE Data Access </font>